### PR TITLE
Added #peek(count) to get more than 1 elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,16 +49,25 @@ RingBuffer.prototype.isFull = function() {
 };
 
 /**
- * Peeks at the top element of the queue.
+ * Peeks at the top element(s) of the queue.
  *
- * @return {Object}
+ * @param {Number} count
+ * @return {Object|Array}
  * @throws {Error} when the ring buffer is empty.
  * @api public
  */
-RingBuffer.prototype.peek = function() {
+RingBuffer.prototype.peek = function(count) {
   if (this.isEmpty()) throw new Error('RingBuffer is empty');
 
-  return this._elements[this._first];
+  if (count === undefined) return this._elements[this._first];
+
+  count = Math.min(count, this.size());
+  var results = new Array(count);
+  for (var i = this._first, c = 0; c < count; i++, c++) {
+    if (i >= this.capacity()) i = 0; // Wrap around to the beginning
+    results[c] = this._elements[i];
+  }
+  return results;
 };
 
 /**

--- a/test/ringbuffer.js
+++ b/test/ringbuffer.js
@@ -54,6 +54,38 @@ describe('RingBuffer()', function() {
       buffer.enq('valentina');
       expect(buffer.peek()).to.be('jano');
     });
+
+    it('returns top 2 elements if passed count of 2', function() {
+      var buffer = new RingBuffer();
+      buffer.enq('jano');
+      buffer.enq('valentina');
+      buffer.enq('rodrigo');
+      var results = buffer.peek(2);
+      expect(results).to.have.length(2);
+      expect(results).to.have.property(0, 'jano');
+      expect(results).to.have.property(1, 'valentina');
+    });
+
+    it('returns top 2 elements if passed count of 2 and even if wrapping', function() {
+      var buffer = new RingBuffer(2);
+      buffer.enq('ignore'); // This will get replaced by valentina
+      buffer.enq('jano');
+      buffer.enq('valentina');
+      var results = buffer.peek(2);
+      expect(results).to.have.length(2);
+      expect(results).to.have.property(0, 'jano');
+      expect(results).to.have.property(1, 'valentina');
+    });
+
+    it('returns all elements if passed count > size', function() {
+      var buffer = new RingBuffer(2);
+      buffer.enq('jano');
+      buffer.enq('valentina');
+      var results = buffer.peek(3);
+      expect(results).to.have.length(2);
+      expect(results).to.have.property(0, 'jano');
+      expect(results).to.have.property(1, 'valentina');
+    });
   });
 
   describe('#deq()', function() {


### PR DESCRIPTION
Use case: If you're building a chat server and want new clients to get the last 3 messages upon joining you would do something like:

``` JS
var buffer = new RingBuffer(3);
function onJoin(client) {
    var msgs = buffer.peek(buffer.size());
    client.write(msgs.join("\n"));
}
```

I tested using `npm test` but couldn't test in the browser since I don't have the build directory I guess? It just kept complaining about `require()` not being defined.
