### PR TITLE
Optional `evictedCb` to observe elements that get evicted.

### DIFF
--- a/test/ringbuffer.js
+++ b/test/ringbuffer.js
@@ -104,6 +104,19 @@ describe('RingBuffer()', function() {
         expect(buffer.enq('valentina')).to.be(2);
         expect(buffer.enq('fran')).to.be(2);
       });
+
+      it('triggers a evicted element callback', function() {
+        var hit = 0;
+        function evictedCb(evicted) {
+          expect(evicted).to.be('jano');
+          ++hit;
+        }
+        var buffer = new RingBuffer(2, evictedCb);
+        expect(buffer.enq('jano')).to.be(1);
+        expect(buffer.enq('valentina')).to.be(2);
+        expect(buffer.enq('fran')).to.be(2);
+        expect(hit).to.be(1);
+      });
     });
   });
 


### PR DESCRIPTION
Provide an option in the constructor for a callback to get to observe any evicted elements.

I had a bunch of deferred objects that I was queueing, and when they got evicted I needed to reject those deferreds. This PR provided a hook to operate on those evicted promises and reject them.
