### PR TITLE
Add peekN and deqN to peek/deq multiple elements

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,6 +51,11 @@ Returns the capacity of the ring buffer.
 Dequeues the top element of the ring buffer.
 Throws an `Error` when the buffer is empty.
 
+### RingBuffer#deqN(count)
+
+Dequeues `count` elements from the top of the ring buffer and returns them.
+Throws an `Error` if there are not enough elements in the buffer.
+
 ### RingBuffer#enq(element)
 
 Enqueues the `element` at the end of the ring buffer and returns its new size.
@@ -68,6 +73,11 @@ Returns whether the ring buffer is full or not.
 
 Peeks at the top element of the ring buffer.
 Throws an `Error` when the buffer is empty.
+
+### RingBuffer#peekN(count)
+
+Returns `count` elements from the top of the ring buffer.
+Throws an `Error` if there are not enough elements in the buffer.
 
 ### RingBuffer#size()
 

--- a/index.js
+++ b/index.js
@@ -62,6 +62,25 @@ RingBuffer.prototype.peek = function() {
 };
 
 /**
+ * Peeks at multiple elements in the queue.
+ *
+ * @return {Array}
+ * @throws {Error} when there are not enough elements in the buffer.
+ * @api public
+ */
+RingBuffer.prototype.peekN = function(count) {
+  if (count > this._size) throw new Error('Not enough elements in RingBuffer');
+
+  var end = Math.min(this._first + count, this.capacity());
+  var firstHalf = this._elements.slice(this._first, end);
+  if (end < this.capacity()) {
+    return firstHalf;
+  }
+  var secondHalf = this._elements.slice(0, count - firstHalf.length);
+  return firstHalf.concat(secondHalf);
+};
+
+/**
  * Dequeues the top element of the queue.
  *
  * @return {Object}
@@ -75,6 +94,22 @@ RingBuffer.prototype.deq = function() {
   this._first = (this._first + 1) % this.capacity();
 
   return element;
+};
+
+/**
+ * Dequeues multiple elements of the queue.
+ *
+ * @return {Array}
+ * @throws {Error} when there are not enough elements in the buffer.
+ * @api public
+ */
+RingBuffer.prototype.deqN = function(count) {
+  var elements = this.peekN(count);
+
+  this._size -= count;
+  this._first = (this._first + count) % this.capacity();
+
+  return elements;
 };
 
 /**

--- a/test/ringbuffer.js
+++ b/test/ringbuffer.js
@@ -56,6 +56,34 @@ describe('RingBuffer()', function() {
     });
   });
 
+  describe('#peekN()', function() {
+    it ('fails when too many elements are requested', function() {
+      var buffer = new RingBuffer();
+      buffer.enq('jano');
+      buffer.enq('valentina');
+      expect(function() {
+        buffer.peekN(3);
+      }).to.throwException('Not enough elements in RingBuffer');
+    });
+
+    it('returns elements of the ring buffer', function() {
+      var buffer = new RingBuffer();
+      buffer.enq('jano');
+      buffer.enq('valentina');
+      expect(buffer.peekN(2)).to.eql(['jano', 'valentina']);
+    });
+
+    it('returns elements when wrapping round', function() {
+      var buffer = new RingBuffer(3);
+      buffer.enq('jano');
+      buffer.enq('valentina');
+      buffer.enq('fran');
+      expect(buffer.deq()).to.be('jano');
+      buffer.enq('herbert');
+      expect(buffer.peekN(3)).to.eql(['valentina', 'fran', 'herbert']);
+    });
+  });
+
   describe('#deq()', function() {
     it('fails when the ring buffer is empty', function() {
       var buffer = new RingBuffer();
@@ -70,6 +98,42 @@ describe('RingBuffer()', function() {
       buffer.enq('valentina');
       expect(buffer.deq()).to.be('jano');
       expect(buffer.size()).to.be(1);
+    });
+  });
+
+  describe('#deqN()', function() {
+    it ('fails when too many elements are requested', function() {
+      var buffer = new RingBuffer();
+      buffer.enq('jano');
+      buffer.enq('valentina');
+      expect(function() {
+        buffer.deqN(3);
+      }).to.throwException('Not enough elements in RingBuffer');
+    });
+
+    it('dequeues elements', function() {
+      var buffer = new RingBuffer();
+      buffer.enq('jano');
+      buffer.enq('valentina');
+      expect(buffer.deqN(2)).to.eql(['jano', 'valentina']);
+      expect(buffer.size()).to.be(0);
+    });
+
+    it('dequeues elements when wrapping round', function() {
+      var buffer = new RingBuffer(3);
+      buffer.enq('jano');
+      buffer.enq('valentina');
+      buffer.enq('fran');
+      buffer.deq(); // jano
+      buffer.enq('herbert'); // at index 0
+      expect(buffer.deqN(3)).to.eql(['valentina', 'fran', 'herbert']);
+      expect(buffer.size()).to.be(0);
+
+      // ensure _first has been set correctly:
+      buffer.enq('jano');
+      buffer.enq('valentina');
+      expect(buffer.deq()).to.be('jano');
+      expect(buffer.deq()).to.be('valentina');
     });
   });
 


### PR DESCRIPTION
A follow-up of #1. Hopefully more efficient by using the native `slice()` instead of for loops.